### PR TITLE
Add popup details

### DIFF
--- a/src/Components/Navbar.js
+++ b/src/Components/Navbar.js
@@ -4,6 +4,7 @@ export default class Navbar extends Component {
   render() {
     return (
       <nav className="Navbar">
+        <i class="fas fa-bars"></i>
         <input
           onChange={this.props.checkFilterInput}
           type="text"

--- a/src/Components/PopUp.js
+++ b/src/Components/PopUp.js
@@ -4,9 +4,16 @@ export default class PopUp extends Component {
   render() {
     const { isSearch, game, closePopUp } = this.props;
     let className = "PopUp";
+    let iconClassName = "fas fa-thermometer-half"
 
     if (isSearch) {
       className = "search-popup"
+    }
+
+    if (game.challenge_level === 'simple') {
+      iconClassName = "fas fa-thermometer-quarter"
+    } else if (game.challenge_level === 'complex') {
+      iconClassName = "fas fa-thermometer-full"
     }
 
     return (
@@ -20,7 +27,10 @@ export default class PopUp extends Component {
             <p class="num-of-minutes"><i class="fas fa-clock"></i> {game.number_of_minutes} min.</p>
           </div>
           <p class="game-description">{game.description}</p>
-          
+          <p class="difficulty-level">
+            Challenge level: {game.challenge_level}
+            <i className={iconClassName}></i>
+          </p>
           <img className="carousel-image" src={game.img} alt="game in box" />
         </section>
 

--- a/src/Components/PopUp.js
+++ b/src/Components/PopUp.js
@@ -18,9 +18,12 @@ export default class PopUp extends Component {
 
     return (
       <div className={className}>
-        <section>
-          <i onClick={closePopUp} className="fas fa-times"></i>
-          <h1 class="game-name">{game.game}</h1>
+        <section class="game-details">
+          
+            <i onClick={closePopUp} className="fas fa-times"></i>
+          <h1 class="game-name">
+            {game.game}
+          </h1>
           <div class="game-info">
             <p class="age-range"><i class="fas fa-birthday-cake"></i> Ages {game.min_age}+</p>
             <p class="num-of-players"><i class="fas fa-users"></i> {game.min_players} - {game.max_players} players</p>
@@ -34,7 +37,7 @@ export default class PopUp extends Component {
           <img className="carousel-image" src={game.img} alt="game in box" />
         </section>
 
-        <section>
+        <section class="youtube-video">
           <iframe
             width="100%"
             height="100%"

--- a/src/Components/PopUp.js
+++ b/src/Components/PopUp.js
@@ -10,11 +10,31 @@ export default class PopUp extends Component {
     }
 
     return (
-      <div className={className}>]
-        <i onClick={closePopUp} className="fas fa-times"></i>
-        <h1>{game.game}</h1>
-        <p>{game.description}</p>
-        <img className="carousel-image" src={game.img} alt="" />
+      <div className={className}>
+        <section>
+          <i onClick={closePopUp} className="fas fa-times"></i>
+          <h1 class="game-name">{game.game}</h1>
+          <div class="game-info">
+            <p class="age-range"><i class="fas fa-birthday-cake"></i> Ages {game.min_age}+</p>
+            <p class="num-of-players"><i class="fas fa-users"></i> {game.min_players} - {game.max_players} players</p>
+            <p class="num-of-minutes"><i class="fas fa-clock"></i> {game.number_of_minutes} min.</p>
+          </div>
+          <p class="game-description">{game.description}</p>
+          
+          <img className="carousel-image" src={game.img} alt="game in box" />
+        </section>
+
+        <section>
+          <iframe
+            width="100%"
+            height="100%"
+            src={`https://www.youtube.com/embed/${game.youtube}?autoplay=0`}
+            frameBorder="0"
+            allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+            title="featured-video">
+          </iframe>
+        </section>
       </div>
     )
   }

--- a/src/Tests/__snapshots__/Carousel.test.js.snap
+++ b/src/Tests/__snapshots__/Carousel.test.js.snap
@@ -45,46 +45,45 @@ ShallowWrapper {
     "props": Object {
       "children": Array [
         <h4
-          className="genre-name"
+          className="genre"
+        />,
+        <i
+          className="fas fa-angle-left"
         />,
         <div
-          className="carousel-bar"
+          className="scroll-container"
         >
-          <div>
-            <i
-              class="fas fa-angle-left"
-            />
-          </div>
-          <div
-            className="scroll-container"
-          >
-            <div
-              className="carousel-game"
-            >
-              <div
-                className="game-card"
-                onClick={[Function]}
-              >
-                <span>
-                  Don't Be A Loser
-                </span>
-                <img
-                  alt="game board"
-                  className="carousel-image"
-                  src="https://cdn.shopify.com/s/files/1/1911/5793/products/DBAL-main-photo-box_350x.jpg?v=1512623523"
-                />
-              </div>
-            </div>
-          </div>
-          <div>
-            <i
-              class="fas fa-angle-right"
-            />
-          </div>
+          <_default
+            createPopUp={[MockFunction]}
+            game={
+              Object {
+                "challenge_level": "average",
+                "description": "Don't Be a Loser is a fun party game where you don't have to win but you just don't want to be the BIG LOSER! This game is easy to play and designed with social situations in mind, allowing players to freely leave and come back without interrupting the game!",
+                "expansion_pack": false,
+                "game": "Don't Be A Loser",
+                "genre_ID": Array [
+                  6,
+                  11,
+                  13,
+                ],
+                "img": "https://cdn.shopify.com/s/files/1/1911/5793/products/DBAL-main-photo-box_350x.jpg?v=1512623523",
+                "max_players": 10,
+                "min_age": 13,
+                "min_players": 4,
+                "number_of_minutes": "30",
+                "publisher": "All Over The Board",
+                "youtube": "ZYvvhOzYx_4",
+              }
+            }
+          />
         </div>,
-        false,
+        <i
+          className="fas fa-angle-right"
+        />,
+        undefined,
       ],
       "className": "Carousel",
+      "data-genre": undefined,
     },
     "ref": null,
     "rendered": Array [
@@ -94,7 +93,7 @@ ShallowWrapper {
         "nodeType": "host",
         "props": Object {
           "children": undefined,
-          "className": "genre-name",
+          "className": "genre",
         },
         "ref": null,
         "rendered": null,
@@ -105,194 +104,90 @@ ShallowWrapper {
         "key": undefined,
         "nodeType": "host",
         "props": Object {
+          "className": "fas fa-angle-left",
+        },
+        "ref": null,
+        "rendered": null,
+        "type": "i",
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
           "children": Array [
-            <div>
-              <i
-                class="fas fa-angle-left"
-              />
-            </div>,
-            <div
-              className="scroll-container"
-            >
-              <div
-                className="carousel-game"
-              >
-                <div
-                  className="game-card"
-                  onClick={[Function]}
-                >
-                  <span>
-                    Don't Be A Loser
-                  </span>
-                  <img
-                    alt="game board"
-                    className="carousel-image"
-                    src="https://cdn.shopify.com/s/files/1/1911/5793/products/DBAL-main-photo-box_350x.jpg?v=1512623523"
-                  />
-                </div>
-              </div>
-            </div>,
-            <div>
-              <i
-                class="fas fa-angle-right"
-              />
-            </div>,
+            <_default
+              createPopUp={[MockFunction]}
+              game={
+                Object {
+                  "challenge_level": "average",
+                  "description": "Don't Be a Loser is a fun party game where you don't have to win but you just don't want to be the BIG LOSER! This game is easy to play and designed with social situations in mind, allowing players to freely leave and come back without interrupting the game!",
+                  "expansion_pack": false,
+                  "game": "Don't Be A Loser",
+                  "genre_ID": Array [
+                    6,
+                    11,
+                    13,
+                  ],
+                  "img": "https://cdn.shopify.com/s/files/1/1911/5793/products/DBAL-main-photo-box_350x.jpg?v=1512623523",
+                  "max_players": 10,
+                  "min_age": 13,
+                  "min_players": 4,
+                  "number_of_minutes": "30",
+                  "publisher": "All Over The Board",
+                  "youtube": "ZYvvhOzYx_4",
+                }
+              }
+            />,
           ],
-          "className": "carousel-bar",
+          "className": "scroll-container",
         },
         "ref": null,
         "rendered": Array [
           Object {
             "instance": null,
-            "key": undefined,
-            "nodeType": "host",
+            "key": "uid1",
+            "nodeType": "class",
             "props": Object {
-              "children": <i
-                class="fas fa-angle-left"
-              />,
+              "createPopUp": [MockFunction],
+              "game": Object {
+                "challenge_level": "average",
+                "description": "Don't Be a Loser is a fun party game where you don't have to win but you just don't want to be the BIG LOSER! This game is easy to play and designed with social situations in mind, allowing players to freely leave and come back without interrupting the game!",
+                "expansion_pack": false,
+                "game": "Don't Be A Loser",
+                "genre_ID": Array [
+                  6,
+                  11,
+                  13,
+                ],
+                "img": "https://cdn.shopify.com/s/files/1/1911/5793/products/DBAL-main-photo-box_350x.jpg?v=1512623523",
+                "max_players": 10,
+                "min_age": 13,
+                "min_players": 4,
+                "number_of_minutes": "30",
+                "publisher": "All Over The Board",
+                "youtube": "ZYvvhOzYx_4",
+              },
             },
             "ref": null,
-            "rendered": Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "host",
-              "props": Object {
-                "class": "fas fa-angle-left",
-              },
-              "ref": null,
-              "rendered": null,
-              "type": "i",
-            },
-            "type": "div",
-          },
-          Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "host",
-            "props": Object {
-              "children": Array [
-                <div
-                  className="carousel-game"
-                >
-                  <div
-                    className="game-card"
-                    onClick={[Function]}
-                  >
-                    <span>
-                      Don't Be A Loser
-                    </span>
-                    <img
-                      alt="game board"
-                      className="carousel-image"
-                      src="https://cdn.shopify.com/s/files/1/1911/5793/products/DBAL-main-photo-box_350x.jpg?v=1512623523"
-                    />
-                  </div>
-                </div>,
-              ],
-              "className": "scroll-container",
-            },
-            "ref": null,
-            "rendered": Array [
-              Object {
-                "instance": null,
-                "key": "[object Object]",
-                "nodeType": "host",
-                "props": Object {
-                  "children": <div
-                    className="game-card"
-                    onClick={[Function]}
-                  >
-                    <span>
-                      Don't Be A Loser
-                    </span>
-                    <img
-                      alt="game board"
-                      className="carousel-image"
-                      src="https://cdn.shopify.com/s/files/1/1911/5793/products/DBAL-main-photo-box_350x.jpg?v=1512623523"
-                    />
-                  </div>,
-                  "className": "carousel-game",
-                },
-                "ref": null,
-                "rendered": Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": Array [
-                      <span>
-                        Don't Be A Loser
-                      </span>,
-                      <img
-                        alt="game board"
-                        className="carousel-image"
-                        src="https://cdn.shopify.com/s/files/1/1911/5793/products/DBAL-main-photo-box_350x.jpg?v=1512623523"
-                      />,
-                    ],
-                    "className": "game-card",
-                    "onClick": [Function],
-                  },
-                  "ref": null,
-                  "rendered": Array [
-                    Object {
-                      "instance": null,
-                      "key": undefined,
-                      "nodeType": "host",
-                      "props": Object {
-                        "children": "Don't Be A Loser",
-                      },
-                      "ref": null,
-                      "rendered": "Don't Be A Loser",
-                      "type": "span",
-                    },
-                    Object {
-                      "instance": null,
-                      "key": undefined,
-                      "nodeType": "host",
-                      "props": Object {
-                        "alt": "game board",
-                        "className": "carousel-image",
-                        "src": "https://cdn.shopify.com/s/files/1/1911/5793/products/DBAL-main-photo-box_350x.jpg?v=1512623523",
-                      },
-                      "ref": null,
-                      "rendered": null,
-                      "type": "img",
-                    },
-                  ],
-                  "type": "div",
-                },
-                "type": "div",
-              },
-            ],
-            "type": "div",
-          },
-          Object {
-            "instance": null,
-            "key": undefined,
-            "nodeType": "host",
-            "props": Object {
-              "children": <i
-                class="fas fa-angle-right"
-              />,
-            },
-            "ref": null,
-            "rendered": Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "host",
-              "props": Object {
-                "class": "fas fa-angle-right",
-              },
-              "ref": null,
-              "rendered": null,
-              "type": "i",
-            },
-            "type": "div",
+            "rendered": null,
+            "type": [Function],
           },
         ],
         "type": "div",
       },
-      false,
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "className": "fas fa-angle-right",
+        },
+        "ref": null,
+        "rendered": null,
+        "type": "i",
+      },
+      undefined,
     ],
     "type": "nav",
   },
@@ -304,46 +199,45 @@ ShallowWrapper {
       "props": Object {
         "children": Array [
           <h4
-            className="genre-name"
+            className="genre"
+          />,
+          <i
+            className="fas fa-angle-left"
           />,
           <div
-            className="carousel-bar"
+            className="scroll-container"
           >
-            <div>
-              <i
-                class="fas fa-angle-left"
-              />
-            </div>
-            <div
-              className="scroll-container"
-            >
-              <div
-                className="carousel-game"
-              >
-                <div
-                  className="game-card"
-                  onClick={[Function]}
-                >
-                  <span>
-                    Don't Be A Loser
-                  </span>
-                  <img
-                    alt="game board"
-                    className="carousel-image"
-                    src="https://cdn.shopify.com/s/files/1/1911/5793/products/DBAL-main-photo-box_350x.jpg?v=1512623523"
-                  />
-                </div>
-              </div>
-            </div>
-            <div>
-              <i
-                class="fas fa-angle-right"
-              />
-            </div>
+            <_default
+              createPopUp={[MockFunction]}
+              game={
+                Object {
+                  "challenge_level": "average",
+                  "description": "Don't Be a Loser is a fun party game where you don't have to win but you just don't want to be the BIG LOSER! This game is easy to play and designed with social situations in mind, allowing players to freely leave and come back without interrupting the game!",
+                  "expansion_pack": false,
+                  "game": "Don't Be A Loser",
+                  "genre_ID": Array [
+                    6,
+                    11,
+                    13,
+                  ],
+                  "img": "https://cdn.shopify.com/s/files/1/1911/5793/products/DBAL-main-photo-box_350x.jpg?v=1512623523",
+                  "max_players": 10,
+                  "min_age": 13,
+                  "min_players": 4,
+                  "number_of_minutes": "30",
+                  "publisher": "All Over The Board",
+                  "youtube": "ZYvvhOzYx_4",
+                }
+              }
+            />
           </div>,
-          false,
+          <i
+            className="fas fa-angle-right"
+          />,
+          undefined,
         ],
         "className": "Carousel",
+        "data-genre": undefined,
       },
       "ref": null,
       "rendered": Array [
@@ -353,7 +247,7 @@ ShallowWrapper {
           "nodeType": "host",
           "props": Object {
             "children": undefined,
-            "className": "genre-name",
+            "className": "genre",
           },
           "ref": null,
           "rendered": null,
@@ -364,194 +258,90 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "host",
           "props": Object {
+            "className": "fas fa-angle-left",
+          },
+          "ref": null,
+          "rendered": null,
+          "type": "i",
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
             "children": Array [
-              <div>
-                <i
-                  class="fas fa-angle-left"
-                />
-              </div>,
-              <div
-                className="scroll-container"
-              >
-                <div
-                  className="carousel-game"
-                >
-                  <div
-                    className="game-card"
-                    onClick={[Function]}
-                  >
-                    <span>
-                      Don't Be A Loser
-                    </span>
-                    <img
-                      alt="game board"
-                      className="carousel-image"
-                      src="https://cdn.shopify.com/s/files/1/1911/5793/products/DBAL-main-photo-box_350x.jpg?v=1512623523"
-                    />
-                  </div>
-                </div>
-              </div>,
-              <div>
-                <i
-                  class="fas fa-angle-right"
-                />
-              </div>,
+              <_default
+                createPopUp={[MockFunction]}
+                game={
+                  Object {
+                    "challenge_level": "average",
+                    "description": "Don't Be a Loser is a fun party game where you don't have to win but you just don't want to be the BIG LOSER! This game is easy to play and designed with social situations in mind, allowing players to freely leave and come back without interrupting the game!",
+                    "expansion_pack": false,
+                    "game": "Don't Be A Loser",
+                    "genre_ID": Array [
+                      6,
+                      11,
+                      13,
+                    ],
+                    "img": "https://cdn.shopify.com/s/files/1/1911/5793/products/DBAL-main-photo-box_350x.jpg?v=1512623523",
+                    "max_players": 10,
+                    "min_age": 13,
+                    "min_players": 4,
+                    "number_of_minutes": "30",
+                    "publisher": "All Over The Board",
+                    "youtube": "ZYvvhOzYx_4",
+                  }
+                }
+              />,
             ],
-            "className": "carousel-bar",
+            "className": "scroll-container",
           },
           "ref": null,
           "rendered": Array [
             Object {
               "instance": null,
-              "key": undefined,
-              "nodeType": "host",
+              "key": "uid1",
+              "nodeType": "class",
               "props": Object {
-                "children": <i
-                  class="fas fa-angle-left"
-                />,
+                "createPopUp": [MockFunction],
+                "game": Object {
+                  "challenge_level": "average",
+                  "description": "Don't Be a Loser is a fun party game where you don't have to win but you just don't want to be the BIG LOSER! This game is easy to play and designed with social situations in mind, allowing players to freely leave and come back without interrupting the game!",
+                  "expansion_pack": false,
+                  "game": "Don't Be A Loser",
+                  "genre_ID": Array [
+                    6,
+                    11,
+                    13,
+                  ],
+                  "img": "https://cdn.shopify.com/s/files/1/1911/5793/products/DBAL-main-photo-box_350x.jpg?v=1512623523",
+                  "max_players": 10,
+                  "min_age": 13,
+                  "min_players": 4,
+                  "number_of_minutes": "30",
+                  "publisher": "All Over The Board",
+                  "youtube": "ZYvvhOzYx_4",
+                },
               },
               "ref": null,
-              "rendered": Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "class": "fas fa-angle-left",
-                },
-                "ref": null,
-                "rendered": null,
-                "type": "i",
-              },
-              "type": "div",
-            },
-            Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "host",
-              "props": Object {
-                "children": Array [
-                  <div
-                    className="carousel-game"
-                  >
-                    <div
-                      className="game-card"
-                      onClick={[Function]}
-                    >
-                      <span>
-                        Don't Be A Loser
-                      </span>
-                      <img
-                        alt="game board"
-                        className="carousel-image"
-                        src="https://cdn.shopify.com/s/files/1/1911/5793/products/DBAL-main-photo-box_350x.jpg?v=1512623523"
-                      />
-                    </div>
-                  </div>,
-                ],
-                "className": "scroll-container",
-              },
-              "ref": null,
-              "rendered": Array [
-                Object {
-                  "instance": null,
-                  "key": "[object Object]",
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": <div
-                      className="game-card"
-                      onClick={[Function]}
-                    >
-                      <span>
-                        Don't Be A Loser
-                      </span>
-                      <img
-                        alt="game board"
-                        className="carousel-image"
-                        src="https://cdn.shopify.com/s/files/1/1911/5793/products/DBAL-main-photo-box_350x.jpg?v=1512623523"
-                      />
-                    </div>,
-                    "className": "carousel-game",
-                  },
-                  "ref": null,
-                  "rendered": Object {
-                    "instance": null,
-                    "key": undefined,
-                    "nodeType": "host",
-                    "props": Object {
-                      "children": Array [
-                        <span>
-                          Don't Be A Loser
-                        </span>,
-                        <img
-                          alt="game board"
-                          className="carousel-image"
-                          src="https://cdn.shopify.com/s/files/1/1911/5793/products/DBAL-main-photo-box_350x.jpg?v=1512623523"
-                        />,
-                      ],
-                      "className": "game-card",
-                      "onClick": [Function],
-                    },
-                    "ref": null,
-                    "rendered": Array [
-                      Object {
-                        "instance": null,
-                        "key": undefined,
-                        "nodeType": "host",
-                        "props": Object {
-                          "children": "Don't Be A Loser",
-                        },
-                        "ref": null,
-                        "rendered": "Don't Be A Loser",
-                        "type": "span",
-                      },
-                      Object {
-                        "instance": null,
-                        "key": undefined,
-                        "nodeType": "host",
-                        "props": Object {
-                          "alt": "game board",
-                          "className": "carousel-image",
-                          "src": "https://cdn.shopify.com/s/files/1/1911/5793/products/DBAL-main-photo-box_350x.jpg?v=1512623523",
-                        },
-                        "ref": null,
-                        "rendered": null,
-                        "type": "img",
-                      },
-                    ],
-                    "type": "div",
-                  },
-                  "type": "div",
-                },
-              ],
-              "type": "div",
-            },
-            Object {
-              "instance": null,
-              "key": undefined,
-              "nodeType": "host",
-              "props": Object {
-                "children": <i
-                  class="fas fa-angle-right"
-                />,
-              },
-              "ref": null,
-              "rendered": Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "class": "fas fa-angle-right",
-                },
-                "ref": null,
-                "rendered": null,
-                "type": "i",
-              },
-              "type": "div",
+              "rendered": null,
+              "type": [Function],
             },
           ],
           "type": "div",
         },
-        false,
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "className": "fas fa-angle-right",
+          },
+          "ref": null,
+          "rendered": null,
+          "type": "i",
+        },
+        undefined,
       ],
       "type": "nav",
     },

--- a/src/Tests/__snapshots__/Featured.test.js.snap
+++ b/src/Tests/__snapshots__/Featured.test.js.snap
@@ -28,10 +28,10 @@ ShallowWrapper {
     "props": Object {
       "children": <iframe
         allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen={true}
-        frameborder="0"
+        allowFullScreen={true}
+        frameBorder="0"
         height="100%"
-        src="https://www.youtube.com/embed/ZYvvhOzYx_4"
+        src="https://www.youtube.com/embed/ZYvvhOzYx_4?autoplay=0"
         title="featured-video"
         width="100%"
       />,
@@ -44,10 +44,10 @@ ShallowWrapper {
       "nodeType": "host",
       "props": Object {
         "allow": "accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture",
-        "allowfullscreen": true,
-        "frameborder": "0",
+        "allowFullScreen": true,
+        "frameBorder": "0",
         "height": "100%",
-        "src": "https://www.youtube.com/embed/ZYvvhOzYx_4",
+        "src": "https://www.youtube.com/embed/ZYvvhOzYx_4?autoplay=0",
         "title": "featured-video",
         "width": "100%",
       },
@@ -65,10 +65,10 @@ ShallowWrapper {
       "props": Object {
         "children": <iframe
           allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-          allowfullscreen={true}
-          frameborder="0"
+          allowFullScreen={true}
+          frameBorder="0"
           height="100%"
-          src="https://www.youtube.com/embed/ZYvvhOzYx_4"
+          src="https://www.youtube.com/embed/ZYvvhOzYx_4?autoplay=0"
           title="featured-video"
           width="100%"
         />,
@@ -81,10 +81,10 @@ ShallowWrapper {
         "nodeType": "host",
         "props": Object {
           "allow": "accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture",
-          "allowfullscreen": true,
-          "frameborder": "0",
+          "allowFullScreen": true,
+          "frameBorder": "0",
           "height": "100%",
-          "src": "https://www.youtube.com/embed/ZYvvhOzYx_4",
+          "src": "https://www.youtube.com/embed/ZYvvhOzYx_4?autoplay=0",
           "title": "featured-video",
           "width": "100%",
         },

--- a/src/Tests/__snapshots__/LandingPage.test.js.snap
+++ b/src/Tests/__snapshots__/LandingPage.test.js.snap
@@ -80,16 +80,22 @@ ShallowWrapper {
               createPopUp={[MockFunction]}
               genre="Strategy"
               matchingGames={Array []}
-              popUpInfo={false}
-            />
+            >
+              <PopUp
+                game={null}
+              />
+            </Carousel>
           </div>,
           <div>
             <Carousel
               createPopUp={[MockFunction]}
               genre="Family"
               matchingGames={Array []}
-              popUpInfo={false}
-            />
+            >
+              <PopUp
+                game={null}
+              />
+            </Carousel>
           </div>,
         ],
       ],
@@ -129,15 +135,18 @@ ShallowWrapper {
       },
       Object {
         "instance": null,
-        "key": "Strategy",
+        "key": "val-Strategy",
         "nodeType": "host",
         "props": Object {
           "children": <Carousel
             createPopUp={[MockFunction]}
             genre="Strategy"
             matchingGames={Array []}
-            popUpInfo={false}
-          />,
+          >
+            <PopUp
+              game={null}
+            />
+          </Carousel>,
         },
         "ref": null,
         "rendered": Object {
@@ -145,29 +154,45 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "class",
           "props": Object {
+            "children": <PopUp
+              game={null}
+            />,
             "closePopUp": undefined,
             "createPopUp": [MockFunction],
             "genre": "Strategy",
             "matchingGames": Array [],
-            "popUpInfo": false,
           },
           "ref": null,
-          "rendered": null,
+          "rendered": Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "closePopUp": undefined,
+              "game": null,
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
           "type": [Function],
         },
         "type": "div",
       },
       Object {
         "instance": null,
-        "key": "Family",
+        "key": "val-Family",
         "nodeType": "host",
         "props": Object {
           "children": <Carousel
             createPopUp={[MockFunction]}
             genre="Family"
             matchingGames={Array []}
-            popUpInfo={false}
-          />,
+          >
+            <PopUp
+              game={null}
+            />
+          </Carousel>,
         },
         "ref": null,
         "rendered": Object {
@@ -175,14 +200,27 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "class",
           "props": Object {
+            "children": <PopUp
+              game={null}
+            />,
             "closePopUp": undefined,
             "createPopUp": [MockFunction],
             "genre": "Family",
             "matchingGames": Array [],
-            "popUpInfo": false,
           },
           "ref": null,
-          "rendered": null,
+          "rendered": Object {
+            "instance": null,
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "closePopUp": undefined,
+              "game": null,
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
           "type": [Function],
         },
         "type": "div",
@@ -227,16 +265,22 @@ ShallowWrapper {
                 createPopUp={[MockFunction]}
                 genre="Strategy"
                 matchingGames={Array []}
-                popUpInfo={false}
-              />
+              >
+                <PopUp
+                  game={null}
+                />
+              </Carousel>
             </div>,
             <div>
               <Carousel
                 createPopUp={[MockFunction]}
                 genre="Family"
                 matchingGames={Array []}
-                popUpInfo={false}
-              />
+              >
+                <PopUp
+                  game={null}
+                />
+              </Carousel>
             </div>,
           ],
         ],
@@ -276,15 +320,18 @@ ShallowWrapper {
         },
         Object {
           "instance": null,
-          "key": "Strategy",
+          "key": "val-Strategy",
           "nodeType": "host",
           "props": Object {
             "children": <Carousel
               createPopUp={[MockFunction]}
               genre="Strategy"
               matchingGames={Array []}
-              popUpInfo={false}
-            />,
+            >
+              <PopUp
+                game={null}
+              />
+            </Carousel>,
           },
           "ref": null,
           "rendered": Object {
@@ -292,29 +339,45 @@ ShallowWrapper {
             "key": undefined,
             "nodeType": "class",
             "props": Object {
+              "children": <PopUp
+                game={null}
+              />,
               "closePopUp": undefined,
               "createPopUp": [MockFunction],
               "genre": "Strategy",
               "matchingGames": Array [],
-              "popUpInfo": false,
             },
             "ref": null,
-            "rendered": null,
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "closePopUp": undefined,
+                "game": null,
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
             "type": [Function],
           },
           "type": "div",
         },
         Object {
           "instance": null,
-          "key": "Family",
+          "key": "val-Family",
           "nodeType": "host",
           "props": Object {
             "children": <Carousel
               createPopUp={[MockFunction]}
               genre="Family"
               matchingGames={Array []}
-              popUpInfo={false}
-            />,
+            >
+              <PopUp
+                game={null}
+              />
+            </Carousel>,
           },
           "ref": null,
           "rendered": Object {
@@ -322,14 +385,27 @@ ShallowWrapper {
             "key": undefined,
             "nodeType": "class",
             "props": Object {
+              "children": <PopUp
+                game={null}
+              />,
               "closePopUp": undefined,
               "createPopUp": [MockFunction],
               "genre": "Family",
               "matchingGames": Array [],
-              "popUpInfo": false,
             },
             "ref": null,
-            "rendered": null,
+            "rendered": Object {
+              "instance": null,
+              "key": undefined,
+              "nodeType": "class",
+              "props": Object {
+                "closePopUp": undefined,
+                "game": null,
+              },
+              "ref": null,
+              "rendered": null,
+              "type": [Function],
+            },
             "type": [Function],
           },
           "type": "div",

--- a/src/Tests/__snapshots__/PopUp.test.js.snap
+++ b/src/Tests/__snapshots__/PopUp.test.js.snap
@@ -39,28 +39,74 @@ ShallowWrapper {
     "nodeType": "host",
     "props": Object {
       "children": Array [
+        "]",
         <i
-          class="fas fa-times"
+          className="fas fa-times"
         />,
-        "Don't Be A Loser",
+        <h1>
+          Don't Be A Loser
+        </h1>,
+        <p>
+          Don't Be a Loser is a fun party game where you don't have to win but you just don't want to be the BIG LOSER! This game is easy to play and designed with social situations in mind, allowing players to freely leave and come back without interrupting the game!
+        </p>,
+        <img
+          alt=""
+          className="carousel-image"
+          src="https://cdn.shopify.com/s/files/1/1911/5793/products/DBAL-main-photo-box_350x.jpg?v=1512623523"
+        />,
       ],
       "className": "PopUp",
     },
     "ref": null,
     "rendered": Array [
+      "]",
       Object {
         "instance": null,
         "key": undefined,
         "nodeType": "host",
         "props": Object {
-          "class": "fas fa-times",
+          "className": "fas fa-times",
           "onClick": undefined,
         },
         "ref": null,
         "rendered": null,
         "type": "i",
       },
-      "Don't Be A Loser",
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": "Don't Be A Loser",
+        },
+        "ref": null,
+        "rendered": "Don't Be A Loser",
+        "type": "h1",
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": "Don't Be a Loser is a fun party game where you don't have to win but you just don't want to be the BIG LOSER! This game is easy to play and designed with social situations in mind, allowing players to freely leave and come back without interrupting the game!",
+        },
+        "ref": null,
+        "rendered": "Don't Be a Loser is a fun party game where you don't have to win but you just don't want to be the BIG LOSER! This game is easy to play and designed with social situations in mind, allowing players to freely leave and come back without interrupting the game!",
+        "type": "p",
+      },
+      Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "alt": "",
+          "className": "carousel-image",
+          "src": "https://cdn.shopify.com/s/files/1/1911/5793/products/DBAL-main-photo-box_350x.jpg?v=1512623523",
+        },
+        "ref": null,
+        "rendered": null,
+        "type": "img",
+      },
     ],
     "type": "div",
   },
@@ -71,28 +117,74 @@ ShallowWrapper {
       "nodeType": "host",
       "props": Object {
         "children": Array [
+          "]",
           <i
-            class="fas fa-times"
+            className="fas fa-times"
           />,
-          "Don't Be A Loser",
+          <h1>
+            Don't Be A Loser
+          </h1>,
+          <p>
+            Don't Be a Loser is a fun party game where you don't have to win but you just don't want to be the BIG LOSER! This game is easy to play and designed with social situations in mind, allowing players to freely leave and come back without interrupting the game!
+          </p>,
+          <img
+            alt=""
+            className="carousel-image"
+            src="https://cdn.shopify.com/s/files/1/1911/5793/products/DBAL-main-photo-box_350x.jpg?v=1512623523"
+          />,
         ],
         "className": "PopUp",
       },
       "ref": null,
       "rendered": Array [
+        "]",
         Object {
           "instance": null,
           "key": undefined,
           "nodeType": "host",
           "props": Object {
-            "class": "fas fa-times",
+            "className": "fas fa-times",
             "onClick": undefined,
           },
           "ref": null,
           "rendered": null,
           "type": "i",
         },
-        "Don't Be A Loser",
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": "Don't Be A Loser",
+          },
+          "ref": null,
+          "rendered": "Don't Be A Loser",
+          "type": "h1",
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": "Don't Be a Loser is a fun party game where you don't have to win but you just don't want to be the BIG LOSER! This game is easy to play and designed with social situations in mind, allowing players to freely leave and come back without interrupting the game!",
+          },
+          "ref": null,
+          "rendered": "Don't Be a Loser is a fun party game where you don't have to win but you just don't want to be the BIG LOSER! This game is easy to play and designed with social situations in mind, allowing players to freely leave and come back without interrupting the game!",
+          "type": "p",
+        },
+        Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "alt": "",
+            "className": "carousel-image",
+            "src": "https://cdn.shopify.com/s/files/1/1911/5793/products/DBAL-main-photo-box_350x.jpg?v=1512623523",
+          },
+          "ref": null,
+          "rendered": null,
+          "type": "img",
+        },
       ],
       "type": "div",
     },

--- a/src/styles/_Carousel.scss
+++ b/src/styles/_Carousel.scss
@@ -33,6 +33,10 @@
   margin: 15px 10px 5px 10px;
 }
 
+.game-card:hover {
+  cursor: pointer;
+}
+
 .carousel-image {
   height: 180px;
   max-width: 400px;

--- a/src/styles/_Carousel.scss
+++ b/src/styles/_Carousel.scss
@@ -10,12 +10,14 @@
   "left mid right"
   "popup popup popup"
 }
+
 .genre{
   grid-area: genre;
   margin: 0px;
   text-align: left;
   font-size: 23px;
 }
+
 .scroll-container {
   grid-area: mid;
   display: flex;
@@ -27,10 +29,9 @@
   height: 78%;
   padding: 24px 0px;
   border-radius: 5px;
-  width:230px;
-  margin:15px 10px 5px 10px;
+  width: 235px;
+  margin: 15px 10px 5px 10px;
 }
-
 
 .carousel-image {
   height: 180px;
@@ -47,16 +48,18 @@ span {
 .fa-angle-left {
   font-size: 30px;
   color: #000;
-  width:5%;
+  width: 5%;
   display: inline-block;
 }
+
 .fa-angle-left{
   grid-area: left;
 }
+
 .fa-angle-right{
-  grid-area:right;
+  grid-area: right;
 }
 
 .PopUp{
-  grid-area:popup;
+  grid-area: popup;
 }

--- a/src/styles/_Carousel.scss
+++ b/src/styles/_Carousel.scss
@@ -34,7 +34,6 @@
 
 .carousel-image {
   height: 180px;
-  width: 90%;
   max-width: 400px;
 }
 

--- a/src/styles/_Navbar.scss
+++ b/src/styles/_Navbar.scss
@@ -1,4 +1,23 @@
 .Navbar {
+  display: flex;
+  justify-content: space-between;
   height: 10%;
   background-color: #2F363D;
+}
+
+.fa-bars {
+  font-size: 30px;
+  padding-left: 7px;
+  color: white;
+  margin: 2%;
+}
+
+.searchbar {
+  width: 200px;
+  height: 30px;
+  border-radius: 5px;
+  font-size: 15px;
+  padding-left: 7px;
+  color: grey;
+  margin: 2%;
 }

--- a/src/styles/_PopUp.scss
+++ b/src/styles/_PopUp.scss
@@ -1,4 +1,33 @@
 .PopUp {
   min-height: 500px;
   background-color: whitesmoke;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+}
+
+
+.game-name {
+  font-size: 30px;
+  margin: 10px auto; 
+  padding-bottom: 15px;
+  border-bottom: 2px black solid;
+}
+
+.game-info {
+  display: flex;
+  justify-content: space-evenly;
+  border-bottom: 2px black solid;
+}
+
+.age-range,
+.num-of-players,
+.num-of-minutes {
+  display: inline-block;
+
+}
+
+.game-description {
+  width: 500px;
+  margin: 10px auto; 
+
 }

--- a/src/styles/_PopUp.scss
+++ b/src/styles/_PopUp.scss
@@ -5,29 +5,45 @@
   grid-template-columns: 1fr 1fr;
 }
 
-
 .game-name {
   font-size: 30px;
   margin: 10px auto; 
   padding-bottom: 15px;
   border-bottom: 2px black solid;
+  margin: 10px auto;
+  width: 500px;
 }
 
 .game-info {
   display: flex;
   justify-content: space-evenly;
   border-bottom: 2px black solid;
+  width: 500px;
+  margin: 10px auto;
 }
 
 .age-range,
 .num-of-players,
 .num-of-minutes {
   display: inline-block;
+}
 
+.difficulty-level {
+  border-bottom: 2px black solid;
+  margin: 10px auto;
+  width: 500px;
+}
+
+.fa-thermometer-quarter,
+.fa-thermometer-half,
+.fa-thermometer-full {
+  font-size: 25px;
+  padding-left: 10px;
 }
 
 .game-description {
   width: 500px;
   margin: 10px auto; 
+  border-bottom: 2px black solid;
 
 }

--- a/src/styles/_PopUp.scss
+++ b/src/styles/_PopUp.scss
@@ -11,11 +11,14 @@
   border: 2px solid grey;
   padding: 1px 1px;
   border-radius: 5px;
-  color: white;
   border-style: outset;
   background-color: darkgray;
-  margin-right: 500px;
-  margin-top: 8px;
+  margin-right: 480px;
+  margin-top: 3px;
+}
+
+.fa-times:hover {
+  cursor: pointer;
 }
 
 .game-name {

--- a/src/styles/_PopUp.scss
+++ b/src/styles/_PopUp.scss
@@ -5,12 +5,24 @@
   grid-template-columns: 1fr 1fr;
 }
 
+.fa-times {
+  position: relative;
+  font-size: 14px;
+  border: 2px solid grey;
+  padding: 1px 1px;
+  border-radius: 5px;
+  color: white;
+  border-style: outset;
+  background-color: darkgray;
+  margin-right: 500px;
+  margin-top: 8px;
+}
+
 .game-name {
   font-size: 30px;
-  margin: 10px auto; 
+  margin: 0px auto;
   padding-bottom: 15px;
   border-bottom: 2px black solid;
-  margin: 10px auto;
   width: 500px;
 }
 
@@ -19,7 +31,7 @@
   justify-content: space-evenly;
   border-bottom: 2px black solid;
   width: 500px;
-  margin: 10px auto;
+  margin: 0px auto 10px auto;
 }
 
 .age-range,
@@ -32,6 +44,8 @@
   border-bottom: 2px black solid;
   margin: 10px auto;
   width: 500px;
+  padding-bottom: 15px;
+
 }
 
 .fa-thermometer-quarter,
@@ -45,5 +59,6 @@
   width: 500px;
   margin: 10px auto; 
   border-bottom: 2px black solid;
+  padding-bottom: 15px;
 
 }

--- a/src/styles/_SearchPage.scss
+++ b/src/styles/_SearchPage.scss
@@ -7,12 +7,16 @@
 }
 
 .SearchPage .search-popup {
-  background-color: #8a2be2;
+  background-color: whitesmoke;
+  border: 6px solid black;
+  border-radius: 5px;
   position: fixed;
   min-height: 40%;
-  min-width: 300px;
+  min-width: 1000px;
   max-width: 550px;
   width: 40%;
-  left: 35%;
-  top: 30%;
+  left: 4%;
+  top: 20%;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
 }


### PR DESCRIPTION
I added card details to the popups for the landing page and search page. All styling is open to changes, this is just to get the general structure going. 

Each PopUp now includes the number of players, playing time, age range, difficulty level, and youtube. I added grid to each popup get the youtube video sitting next to the game details. I also added conditional rendering of the difficulty level icon so that it matches according to whether it's simple, average, or complex. 

I also added a hamburger to our navbar (currently not functional in any way) and styled the search bar.